### PR TITLE
feat: add calendar view with events list, event detail, and event info

### DIFF
--- a/public/mocks/README-MOCK-STRUCTURE.md
+++ b/public/mocks/README-MOCK-STRUCTURE.md
@@ -1,0 +1,81 @@
+# Mock JSON structure overview
+
+How each mock file is shaped and what each ID represents.
+
+## Summary table
+
+| File                | Top-level shape         | Top-level key   | IDs inside              |
+|---------------------|-------------------------|-----------------|-------------------------|
+| eventCategories     | `{ items: [...] }`      | —               | Category id (string)    |
+| eventCategoryDetail | `{ "0": {...}, ... }`   | Category id     | Event id (number) in items |
+| event               | `{ "0": {...}, ... }`   | Event id        | Song id in `songs[]`    |
+| songs               | `{ items: [...] }`     | —               | Song id (string)        |
+
+---
+
+## 1. `eventCategories.json`
+
+```json
+{
+  "items": [
+    { "id": "0", "name": "Adventné obdobie" },
+    { "id": "1", "name": "Vianočné obdobie" },
+    ...
+  ]
+}
+```
+
+- **Structure:** Single object with one array `items`.
+- **IDs:** Each item has `id` (string `"0"`–`"8"`) = **category ID**.
+- **Used by:** `CalendarSidebar` (sidebar links `?category=0`, etc.).
+
+---
+
+## 2. `eventCategoryDetail.json`
+
+```json
+{
+  "0": { "items": [ { "id": 0, "name": "...", "description": "...", "date": {...} }, ... ] },
+  "1": { "items": [ { "id": 2, "name": "...", ... }, ... ] },
+  ...
+}
+```
+
+- **Structure:** Top-level keys are **category IDs** (`"0"`, `"1"`, …). Each value is `{ items: [...] }`.
+- **IDs:** Top-level key = **category ID**. Each item in `items` has `id` (number 0–17) = **event ID**.
+- **Used by:** `EventsList`: `data[categoryId].items` for the selected category.
+
+---
+
+## 3. `event.json`
+
+```json
+{
+  "0": { "id": 0, "name": "...", "description": "...", "date": {...}, "songs": [ { "id": "1", "eventPart": "Introit", ... }, ... ] },
+  "1": { "id": 1, ... },
+  ...
+}
+```
+
+- **Structure:** Top-level keys are **event IDs** (string `"0"`–`"17"`). Each value is the full event (name, description, date, songs).
+- **IDs:** Top-level key = **event ID**. Each entry in `songs` has `id` (string) = **song ID** (references `songs.json`).
+- **Used by:** `useEventDetail` / `useEventDetails`: `events[id]` for event detail; song ids are merged with `songs.json`.
+
+---
+
+## 4. `songs.json`
+
+```json
+{
+  "items": [
+    { "id": "1", "title": "...", "author": "...", "hymnal": "JKS", "tags": [...] },
+    ...
+  ]
+}
+```
+
+- **Structure:** Single object with one array `items`.
+- **IDs:** Each item has `id` (string) = **song ID** (referenced from `event.json` `songs`).
+- **Used by:** `useEventDetail` / `useEventDetails` (merged with event songs for title, author, hymnal, tags).
+
+---

--- a/public/mocks/event.json
+++ b/public/mocks/event.json
@@ -1,29 +1,183 @@
 {
-  "event": {
+  "0": {
     "id": 0,
     "name": "1. nedela v roku A",
     "description": "Lorem ipsum",
-    "date": {
-      "day": 1,
-      "month": 12
-    },
+    "date": {"day": 1, "month": 12},
     "songs": [
-      {
-        "id": "1",
-        "title": "Nazov piesne 1",
-        "songPart": 5,
-        "songPartName": "piata sloha",
-        "prescribed": true,
-        "eventPart": "Introit"
-      },
-      {
-        "id": "2",
-        "title": "Nazov piesne 2",
-        "songPart": null,
-        "songPartName": null,
-        "prescribed": false,
-        "eventPart": "Zaver"
-      }
+      {"id": "1", "songPart": 5, "songPartName": "piata sloha", "prescribed": true, "eventPart": "Introit"},
+      {"id": "2", "songPart": null, "songPartName": null, "prescribed": false, "eventPart": "Zaver"}
+    ]
+  },
+  "1": {
+    "id": 1,
+    "name": "2. nedela v roku A",
+    "description": "Lorem ipsum - viac informacii",
+    "date": null,
+    "songs": [
+      {"id": "3", "songPart": null, "songPartName": null, "prescribed": false, "eventPart": "Introit"},
+      {"id": "4", "songPart": null, "songPartName": null, "prescribed": true, "eventPart": "Zalm"}
+    ]
+  },
+  "2": {
+    "id": 2,
+    "name": "Slávnosť Narodenia Pána",
+    "description": "Slávnosť narodenia Ježiša Krista. Tradičné hymny a žalmy.",
+    "date": {"day": 25, "month": 12},
+    "songs": [
+      {"id": "10", "songPart": null, "songPartName": null, "prescribed": true, "eventPart": "Introit"},
+      {"id": "11", "songPart": null, "songPartName": null, "prescribed": false, "eventPart": "Zalm"},
+      {"id": "12", "songPart": null, "songPartName": null, "prescribed": false, "eventPart": "Zaver"}
+    ]
+  },
+  "3": {
+    "id": 3,
+    "name": "Sviatok Svätej Rodiny",
+    "description": "Sviatok Pána Ježiša, Panny Márie a sv. Jozefa.",
+    "date": {"day": 29, "month": 12},
+    "songs": [
+      {"id": "13", "songPart": null, "songPartName": null, "prescribed": true, "eventPart": "Introit"},
+      {"id": "14", "songPart": null, "songPartName": null, "prescribed": false, "eventPart": "Zalm"}
+    ]
+  },
+  "4": {
+    "id": 4,
+    "name": "1. nedela pôstna",
+    "description": "Začiatok pôstneho obdobia. Priprava na Veľkú noc.",
+    "date": {"day": 22, "month": 2},
+    "songs": [
+      {"id": "15", "songPart": null, "songPartName": null, "prescribed": true, "eventPart": "Introit"},
+      {"id": "16", "songPart": null, "songPartName": null, "prescribed": false, "eventPart": "Zaver"}
+    ]
+  },
+  "5": {
+    "id": 5,
+    "name": "Kvetná nedeľa",
+    "description": "Vjazd Pána do Jeruzalema. Pašiové čítania.",
+    "date": {"day": 2, "month": 4},
+    "songs": [
+      {"id": "17", "songPart": null, "songPartName": null, "prescribed": true, "eventPart": "Introit"},
+      {"id": "18", "songPart": null, "songPartName": null, "prescribed": true, "eventPart": "Zalm"}
+    ]
+  },
+  "6": {
+    "id": 6,
+    "name": "Veľkonočná vigília",
+    "description": "Slávnosť zmŕtvychvstania. Vigília so sviečkou a liturgiou krstu.",
+    "date": {"day": 4, "month": 4},
+    "songs": [
+      {"id": "19", "songPart": null, "songPartName": null, "prescribed": true, "eventPart": "Introit"},
+      {"id": "20", "songPart": null, "songPartName": null, "prescribed": true, "eventPart": "Zalm"}
+    ]
+  },
+  "7": {
+    "id": 7,
+    "name": "Slávnosť Zmŕtvychvstania Pána",
+    "description": "Veľkonočná nedeľa. Kristus vstal z mŕtvych.",
+    "date": {"day": 5, "month": 4},
+    "songs": [
+      {"id": "21", "songPart": null, "songPartName": null, "prescribed": true, "eventPart": "Introit"},
+      {"id": "22", "songPart": null, "songPartName": null, "prescribed": false, "eventPart": "Zaver"}
+    ]
+  },
+  "8": {
+    "id": 8,
+    "name": "2. nedela cez rok",
+    "description": "Cezročné obdobie. Liturgia slova a eucharistie.",
+    "date": {"day": 14, "month": 1},
+    "songs": [
+      {"id": "23", "songPart": null, "songPartName": null, "prescribed": true, "eventPart": "Introit"},
+      {"id": "24", "songPart": null, "songPartName": null, "prescribed": false, "eventPart": "Zalm"}
+    ]
+  },
+  "9": {
+    "id": 9,
+    "name": "3. nedela cez rok",
+    "description": "Lorem ipsum - viac informacii. Cezročné slavenie.",
+    "date": {"day": 21, "month": 1},
+    "songs": [
+      {"id": "25", "songPart": null, "songPartName": null, "prescribed": true, "eventPart": "Introit"},
+      {"id": "26", "songPart": null, "songPartName": null, "prescribed": false, "eventPart": "Zaver"}
+    ]
+  },
+  "10": {
+    "id": 10,
+    "name": "Slávnosť Najsvätejšej Trojice",
+    "description": "Slávnosť Otca, Syna a Ducha Svätého. Teologické hymny.",
+    "date": {"day": 30, "month": 5},
+    "songs": [
+      {"id": "27", "songPart": null, "songPartName": null, "prescribed": true, "eventPart": "Introit"},
+      {"id": "28", "songPart": null, "songPartName": null, "prescribed": false, "eventPart": "Zalm"}
+    ]
+  },
+  "11": {
+    "id": 11,
+    "name": "Telo a krv Pána",
+    "description": "Slávnosť Najsvätejšej eucharistie. Procesia a adorácia.",
+    "date": {"day": 11, "month": 6},
+    "songs": [
+      {"id": "29", "songPart": null, "songPartName": null, "prescribed": true, "eventPart": "Introit"},
+      {"id": "30", "songPart": null, "songPartName": null, "prescribed": true, "eventPart": "Zaver"}
+    ]
+  },
+  "12": {
+    "id": 12,
+    "name": "Sviatok sv. Štefana",
+    "description": "Prvý mučeník. Diakon a kazateľ.",
+    "date": {"day": 26, "month": 12},
+    "songs": [
+      {"id": "31", "songPart": null, "songPartName": null, "prescribed": true, "eventPart": "Introit"},
+      {"id": "32", "songPart": null, "songPartName": null, "prescribed": false, "eventPart": "Zalm"}
+    ]
+  },
+  "13": {
+    "id": 13,
+    "name": "Sviatok sv. Jána Evanjelistu",
+    "description": "Apoštol a evanjelista. Autor Apokalypsy.",
+    "date": {"day": 27, "month": 12},
+    "songs": [
+      {"id": "33", "songPart": null, "songPartName": null, "prescribed": true, "eventPart": "Introit"},
+      {"id": "34", "songPart": null, "songPartName": null, "prescribed": false, "eventPart": "Zaver"}
+    ]
+  },
+  "14": {
+    "id": 14,
+    "name": "Spoločná omša",
+    "description": "Omša za rôzne príležitosti. Spoločné čítania a modlitby.",
+    "date": null,
+    "songs": [
+      {"id": "35", "songPart": null, "songPartName": null, "prescribed": true, "eventPart": "Introit"},
+      {"id": "36", "songPart": null, "songPartName": null, "prescribed": false, "eventPart": "Zalm"}
+    ]
+  },
+  "15": {
+    "id": 15,
+    "name": "Omša za rôzne potreby",
+    "description": "Lorem ipsum - viac informacii. Za úmysly, vďaky, pokánie.",
+    "date": null,
+    "songs": [
+      {"id": "37", "songPart": null, "songPartName": null, "prescribed": false, "eventPart": "Introit"},
+      {"id": "38", "songPart": null, "songPartName": null, "prescribed": false, "eventPart": "Zaver"}
+    ]
+  },
+  "16": {
+    "id": 16,
+    "name": "Svätba",
+    "description": "Svätobná omša. Manželský sľub a požehnanie.",
+    "date": null,
+    "songs": [
+      {"id": "39", "songPart": null, "songPartName": null, "prescribed": false, "eventPart": "Introit"},
+      {"id": "40", "songPart": null, "songPartName": null, "prescribed": false, "eventPart": "Zalm"}
+    ]
+  },
+  "17": {
+    "id": 17,
+    "name": "Pohreb",
+    "description": "Omša za zosnulých. Requiem a večný pokoj.",
+    "date": null,
+    "songs": [
+      {"id": "41", "songPart": null, "songPartName": null, "prescribed": true, "eventPart": "Introit"},
+      {"id": "42", "songPart": null, "songPartName": null, "prescribed": false, "eventPart": "Zaver"}
     ]
   }
 }

--- a/public/mocks/eventCategories.json
+++ b/public/mocks/eventCategories.json
@@ -35,6 +35,6 @@
     {
       "id": "8",
       "name": "Sviatosti, sväteniny a za zosnulých"
-    },
+    }
   ]
 }

--- a/public/mocks/eventCategoryDetail.json
+++ b/public/mocks/eventCategoryDetail.json
@@ -1,19 +1,56 @@
 {
-  "items": [
-    {
-      "id": 0,
-      "name": "1. nedela v roku A",
-      "description": "Lorem ipsum",
-      "date": {
-        "day": 1,
-        "month": 12
-      }
-    },
-    {
-      "id": 1,
-      "name": "2. nedela v roku A",
-      "description": "Lorem ipsum",
-      "date": null
-    }
-  ]
+  "0": {
+    "items": [
+      {"id": 0, "name": "1. nedela v roku A", "description": "Lorem ipsum", "date": {"day": 1, "month": 12}},
+      {"id": 1, "name": "2. nedela v roku A", "description": "Lorem ipsum", "date": null}
+    ]
+  },
+  "1": {
+    "items": [
+      {"id": 2, "name": "Slávnosť Narodenia Pána", "description": "Lorem ipsum", "date": {"day": 25, "month": 12}},
+      {"id": 3, "name": "Sviatok Svätej Rodiny", "description": "Lorem ipsum", "date": {"day": 29, "month": 12}}
+    ]
+  },
+  "2": {
+    "items": [
+      {"id": 4, "name": "1. nedela pôstna", "description": "Lorem ipsum", "date": {"day": 22, "month": 2}},
+      {"id": 5, "name": "Kvetná nedeľa", "description": "Lorem ipsum", "date": {"day": 2, "month": 4}}
+    ]
+  },
+  "3": {
+    "items": [
+      {"id": 6, "name": "Veľkonočná vigília", "description": "Lorem ipsum", "date": {"day": 4, "month": 4}},
+      {"id": 7, "name": "Slávnosť Zmŕtvychvstania Pána", "description": "Lorem ipsum", "date": {"day": 5, "month": 4}}
+    ]
+  },
+  "4": {
+    "items": [
+      {"id": 8, "name": "2. nedela cez rok", "description": "Lorem ipsum", "date": {"day": 14, "month": 1}},
+      {"id": 9, "name": "3. nedela cez rok", "description": "Lorem ipsum - viac informacii", "date": {"day": 21, "month": 1}}
+    ]
+  },
+  "5": {
+    "items": [
+      {"id": 10, "name": "Slávnosť Najsvätejšej Trojice", "description": "Lorem ipsum", "date": {"day": 30, "month": 5}},
+      {"id": 11, "name": "Telo a krv Pána", "description": "Lorem ipsum", "date": {"day": 11, "month": 6}}
+    ]
+  },
+  "6": {
+    "items": [
+      {"id": 12, "name": "Sviatok sv. Štefana", "description": "Lorem ipsum", "date": {"day": 26, "month": 12}},
+      {"id": 13, "name": "Sviatok sv. Jána Evanjelistu", "description": "Lorem ipsum", "date": {"day": 27, "month": 12}}
+    ]
+  },
+  "7": {
+    "items": [
+      {"id": 14, "name": "Spoločná omša", "description": "Lorem ipsum", "date": null},
+      {"id": 15, "name": "Omša za rôzne potreby", "description": "Lorem ipsum - viac informacii", "date": null}
+    ]
+  },
+  "8": {
+    "items": [
+      {"id": 16, "name": "Svätba", "description": "Lorem ipsum", "date": null},
+      {"id": 17, "name": "Pohreb", "description": "Lorem ipsum", "date": null}
+    ]
+  }
 }

--- a/public/mocks/songs.json
+++ b/public/mocks/songs.json
@@ -23,9 +23,28 @@
       "tags": ["Introit", "Offertorium"]
     },
     {
-      "id": "1",
+      "id": "4",
       "title": "Ty si Pane v kazdom chrame",
       "author": "Mikulas Schneider-Trnavsky"
+    },
+    {
+      "id": "10",
+      "title": "Narodil sa Kristus Pán",
+      "author": "trad.",
+      "hymnalNumber": "1",
+      "hymnal": "JKS"
+    },
+    {
+      "id": "11",
+      "title": "Pastierska omša",
+      "author": "",
+      "hymnal": "JKS"
+    },
+    {
+      "id": "12",
+      "title": "Tichá noc",
+      "author": "F. Gruber",
+      "hymnal": "JKS"
     }
   ]
 }

--- a/src/components/songList/SongList.tsx
+++ b/src/components/songList/SongList.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react';
 import { useBem } from '@musica-sacra/hooks';
 import { SongListItem } from './SongListItem';
 import { Hr } from '../hr/Hr';
@@ -7,17 +8,17 @@ import { Loader } from '@musica-sacra/loader';
 export function SongList() {
     const { bem } = useBem('song-list');
 
-    const { query } = useGetList('mocks/songs.json', 'songs');
+    const { query } = useGetList('/mocks/songs.json', 'songs');
 
     return (
         <div className={bem()}>
             <div className={bem('songs')}>
                 <Loader loading={query.isLoading}>
                     {query.data?.items?.map((song) => (
-                        <>
-                            <SongListItem key={song.id} song={song} />
+                        <Fragment key={song.id}>
+                            <SongListItem song={song} />
                             <Hr />
-                        </>
+                        </Fragment>
                     ))}
                 </Loader>
             </div>

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -17,7 +17,7 @@ type TableColumn<T> = {
     label: string;
     size: ColumnSize;
     isSortFilter: boolean;
-    render?: (value: any, row: T) => ReactNode;
+    render?: (value: unknown, row: T) => ReactNode;
 };
 
 type TableProps<T extends Record<string, ReactNode>> = {

--- a/src/router/ProtectedRoutes.tsx
+++ b/src/router/ProtectedRoutes.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Outlet } from 'react-router';
+import { Outlet } from 'react-router';
 import { Role } from './roles';
 import { useContext, useEffect } from 'react';
 import {
@@ -6,8 +6,6 @@ import {
     NotificationTypes,
 } from '@musica-sacra/notifications';
 import { useUser } from '../context/userContext/useUser';
-import { Container } from '@musica-sacra/layout';
-import { Loader } from '@musica-sacra/loader';
 
 type ProtectedRoutesProps = {
     allowedRoles: Role[];

--- a/src/router/paths.ts
+++ b/src/router/paths.ts
@@ -6,7 +6,8 @@ export const Paths = Object.freeze({
 
     ABOUT: '/about-the-project',
 
-    CALENDAR: '/calendar/*',
+    CALENDAR: '/calendar',
+    CALENDAR_EVENT_DETAIL: ':id',
 
     SONG_DETAIL: '/song/:id/*',
 

--- a/src/router/routers/MainRouter.tsx
+++ b/src/router/routers/MainRouter.tsx
@@ -10,13 +10,18 @@ import { AboutView } from '../../views/aboutView/AboutView';
 import { RegisterView } from '../../views/registerView/RegisterView';
 import { SongView } from '../../views/songView/SongView';
 import { CalendarView } from '../../views/calendarView/CalendarView';
+import { EventsList } from '../../views/calendarView/EventsList';
+import { EventDetail } from '../../views/calendarView/EventDetail';
 import { UserDetailView } from '../../views/userDetailView/UserDetailView';
 
 export function MainRouter() {
     return (
         <Routes>
             <Route path={Paths.HOMEPAGE} element={<HomepageView />} />
-            <Route path={Paths.CALENDAR} element={<CalendarView />} />
+            <Route path={Paths.CALENDAR} element={<CalendarView />}>
+                <Route index element={<EventsList />} />
+                <Route path={Paths.CALENDAR_EVENT_DETAIL} element={<EventDetail />} />
+            </Route>
             <Route path={Paths.ABOUT} element={<AboutView />} />
             <Route path={Paths.LOGIN} element={<LoginView />} />
             <Route path={Paths.REGISTER} element={<RegisterView />} />

--- a/src/router/routers/MainRouter.tsx
+++ b/src/router/routers/MainRouter.tsx
@@ -20,7 +20,10 @@ export function MainRouter() {
             <Route path={Paths.HOMEPAGE} element={<HomepageView />} />
             <Route path={Paths.CALENDAR} element={<CalendarView />}>
                 <Route index element={<EventsList />} />
-                <Route path={Paths.CALENDAR_EVENT_DETAIL} element={<EventDetail />} />
+                <Route
+                    path={Paths.CALENDAR_EVENT_DETAIL}
+                    element={<EventDetail />}
+                />
             </Route>
             <Route path={Paths.ABOUT} element={<AboutView />} />
             <Route path={Paths.LOGIN} element={<LoginView />} />

--- a/src/views/calendarView/CalendarSidebar.tsx
+++ b/src/views/calendarView/CalendarSidebar.tsx
@@ -11,7 +11,10 @@ export function CalendarSidebar() {
     const [searchParams] = useSearchParams();
     const currentCategoryId = searchParams.get('category') ?? '';
 
-    const { query } = useGetList<EventCategory>('/mocks/eventCategories.json', 'eventCategories');
+    const { query } = useGetList<EventCategory>(
+        '/mocks/eventCategories.json',
+        'eventCategories'
+    );
 
     return (
         <div className={bem()}>

--- a/src/views/calendarView/CalendarSidebar.tsx
+++ b/src/views/calendarView/CalendarSidebar.tsx
@@ -1,0 +1,39 @@
+import { useBem } from '@musica-sacra/hooks';
+import { NavLink, useSearchParams } from 'react-router';
+import { useGetList } from '@musica-sacra/api';
+import { Loader } from '@musica-sacra/loader';
+import { Paths } from '../../router/paths';
+
+type EventCategory = { id: string; name: string };
+
+export function CalendarSidebar() {
+    const { bem } = useBem('view-calendar-sidebar');
+    const [searchParams] = useSearchParams();
+    const currentCategoryId = searchParams.get('category') ?? '';
+
+    const { query } = useGetList<EventCategory>('/mocks/eventCategories.json', 'eventCategories');
+
+    return (
+        <div className={bem()}>
+            <h2 className={bem('title')}>Kalendar</h2>
+            <h3 className={bem('subtitle')}>Slávenia</h3>
+            <Loader loading={query.isLoading}>
+                <nav className={bem('nav')} aria-label="Kategórie kalendára">
+                    {query.data?.items?.map((category) => {
+                        const to = `${Paths.CALENDAR}?category=${category.id}`;
+                        const isActive = currentCategoryId === category.id;
+                        return (
+                            <NavLink
+                                key={category.id}
+                                to={to}
+                                className={bem('link', { active: isActive })}
+                            >
+                                {category.name}
+                            </NavLink>
+                        );
+                    })}
+                </nav>
+            </Loader>
+        </div>
+    );
+}

--- a/src/views/calendarView/CalendarView.tsx
+++ b/src/views/calendarView/CalendarView.tsx
@@ -1,5 +1,7 @@
 import { useBem } from '@musica-sacra/hooks';
 import { Queen } from '@musica-sacra/layout';
+import { Outlet } from 'react-router';
+import { CalendarSidebar } from './CalendarSidebar';
 
 export function CalendarView() {
     const { bem } = useBem('view-calendar');
@@ -7,10 +9,14 @@ export function CalendarView() {
     return (
         <Queen
             isPageLayout={true}
-            sidebar={<div>Sidebar</div>}
+            sidebar={
+                <div className={bem('sidebar')}>
+                    <CalendarSidebar />
+                </div>
+            }
             className={bem()}
         >
-            <div>Calendar</div>
+            <Outlet />
         </Queen>
     );
 }

--- a/src/views/calendarView/ChevronIcon.tsx
+++ b/src/views/calendarView/ChevronIcon.tsx
@@ -1,0 +1,30 @@
+type ChevronIconProps = {
+    direction: 'up' | 'down';
+    className?: string;
+    'aria-hidden'?: boolean;
+};
+
+/** V-shaped chevron (stroke, no fill). Use for expand/collapse or list indicators. */
+export function ChevronIcon({ direction, className, 'aria-hidden': ariaHidden }: ChevronIconProps) {
+    const isUp = direction === 'up';
+    const size = 12;
+    const strokeWidth = 1.5;
+    const points = isUp ? `2,10 6,4 10,10` : `2,4 6,10 10,4`;
+
+    return (
+        <svg
+            width={size}
+            height={size}
+            viewBox="0 0 12 12"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={className}
+            aria-hidden={ariaHidden}
+        >
+            <polyline points={points} />
+        </svg>
+    );
+}

--- a/src/views/calendarView/ChevronIcon.tsx
+++ b/src/views/calendarView/ChevronIcon.tsx
@@ -5,7 +5,11 @@ type ChevronIconProps = {
 };
 
 /** V-shaped chevron (stroke, no fill). Use for expand/collapse or list indicators. */
-export function ChevronIcon({ direction, className, 'aria-hidden': ariaHidden }: ChevronIconProps) {
+export function ChevronIcon({
+    direction,
+    className,
+    'aria-hidden': ariaHidden,
+}: ChevronIconProps) {
     const isUp = direction === 'up';
     const size = 12;
     const strokeWidth = 1.5;

--- a/src/views/calendarView/EventDetail.tsx
+++ b/src/views/calendarView/EventDetail.tsx
@@ -1,0 +1,17 @@
+import { useBem } from '@musica-sacra/hooks';
+import { EventInfo } from './EventInfo';
+
+/**
+ * Page for a single event (route /calendar/:id).
+ * Opened when user clicks an event from the calendar list (e.g. event name).
+ * Renders EventInfo (general info + songs). Add more sections here later (e.g. full detail, related content).
+ */
+export function EventDetail() {
+    const { bem } = useBem('view-calendar-event-detail');
+
+    return (
+        <div className={bem()}>
+            <EventInfo />
+        </div>
+    );
+}

--- a/src/views/calendarView/EventInfo.tsx
+++ b/src/views/calendarView/EventInfo.tsx
@@ -13,8 +13,7 @@ import {
 
 const EMPTY_SONGS_MESSAGE =
     'Pre toto slavenie nie sú aktuálne dostupné žiadne piesne.';
-const SONG_UNAVAILABLE_MESSAGE =
-    'Ľutujeme, detaily k piesni nie sú dostupné.';
+const SONG_UNAVAILABLE_MESSAGE = 'Ľutujeme, detaily k piesni nie sú dostupné.';
 
 /**
  * General info for one event: name, date, song list (expandable tags).
@@ -24,7 +23,9 @@ export function EventInfo() {
     const { bem } = useBem('view-calendar-event-info');
     const { id } = useParams<{ id: string }>();
     const { data: event, isLoading, isError } = useEventDetail(id);
-    const [expandedSongIds, setExpandedSongIds] = useState<Set<string>>(new Set());
+    const [expandedSongIds, setExpandedSongIds] = useState<Set<string>>(
+        new Set()
+    );
 
     if (!id) {
         return <div className={bem()}>Event ID is required.</div>;
@@ -44,7 +45,9 @@ export function EventInfo() {
             <div className={bem('content')}>
                 <aside className={bem('meta')}>
                     <h2 className={bem('meta-title')}>{event.name}</h2>
-                    <p className={bem('meta-date')}>{formatDate(event.date, 'datum')}</p>
+                    <p className={bem('meta-date')}>
+                        {formatDate(event.date, 'datum')}
+                    </p>
                 </aside>
                 <div className={bem('songs')}>
                     {!hasMappedSongs ? (
@@ -54,18 +57,18 @@ export function EventInfo() {
                     ) : (
                         <ol className={bem('song-list')}>
                             {mappedSongs.map((song) => {
-                                const isSongExpanded =
-                                    expandedSongIds.has(song.id);
-                                const sortedTags =
-                                    getSortedTags(song.tags);
-                                const hasTagsToShow =
-                                    sortedTags.length > 0;
+                                const isSongExpanded = expandedSongIds.has(
+                                    song.id
+                                );
+                                const sortedTags = getSortedTags(song.tags);
+                                const hasTagsToShow = sortedTags.length > 0;
                                 const showUnavailableRollout =
                                     isSongExpanded && !hasTagsToShow;
                                 const toggleSongExpanded = () => {
                                     setExpandedSongIds((prev) => {
                                         const next = new Set(prev);
-                                        if (next.has(song.id)) next.delete(song.id);
+                                        if (next.has(song.id))
+                                            next.delete(song.id);
                                         else next.add(song.id);
                                         return next;
                                     });
@@ -80,36 +83,24 @@ export function EventInfo() {
                                         <div className={bem('song-row')}>
                                             <button
                                                 type="button"
-                                                className={bem(
-                                                    'song-title'
-                                                )}
+                                                className={bem('song-title')}
                                                 onClick={toggleSongExpanded}
                                             >
                                                 {song.title}
                                             </button>
                                             <span
-                                                className={bem(
-                                                    'song-author'
-                                                )}
+                                                className={bem('song-author')}
                                             >
                                                 {song.author ?? ''}
                                             </span>
-                                            <span
-                                                className={bem(
-                                                    'song-meta'
-                                                )}
-                                            >
+                                            <span className={bem('song-meta')}>
                                                 {song.hymnal ?? ''}
                                             </span>
                                             <button
                                                 type="button"
-                                                className={bem(
-                                                    'song-chevron'
-                                                )}
+                                                className={bem('song-chevron')}
                                                 onClick={toggleSongExpanded}
-                                                aria-expanded={
-                                                    isSongExpanded
-                                                }
+                                                aria-expanded={isSongExpanded}
                                                 aria-label={
                                                     isSongExpanded
                                                         ? 'Zbaliť'
@@ -135,20 +126,18 @@ export function EventInfo() {
                                                     'song-tags-rollout'
                                                 )}
                                             >
-                                                {sortedTags.map(
-                                                    (tag, i) => (
-                                                        <span
-                                                            key={tag}
-                                                            className={bem(
-                                                                'song-tag'
-                                                            )}
-                                                        >
-                                                            {TAG_LETTERS[i] ??
-                                                                `${i + 1}.`}.{' '}
-                                                            {tag}
-                                                        </span>
-                                                    )
-                                                )}
+                                                {sortedTags.map((tag, i) => (
+                                                    <span
+                                                        key={tag}
+                                                        className={bem(
+                                                            'song-tag'
+                                                        )}
+                                                    >
+                                                        {TAG_LETTERS[i] ??
+                                                            `${i + 1}.`}
+                                                        . {tag}
+                                                    </span>
+                                                ))}
                                             </div>
                                         )}
                                         {showUnavailableRollout && (

--- a/src/views/calendarView/EventInfo.tsx
+++ b/src/views/calendarView/EventInfo.tsx
@@ -1,0 +1,179 @@
+import { useState } from 'react';
+import { useBem } from '@musica-sacra/hooks';
+import { useParams } from 'react-router';
+import { Loader } from '@musica-sacra/loader';
+import { useEventDetail } from './useEventDetail';
+import { ChevronIcon } from './ChevronIcon';
+import {
+    formatDate,
+    getSortedTags,
+    TAG_LETTERS,
+    hasSongTitle,
+} from './calendarViewUtils';
+
+const EMPTY_SONGS_MESSAGE =
+    'Pre toto slavenie nie sú aktuálne dostupné žiadne piesne.';
+const SONG_UNAVAILABLE_MESSAGE =
+    'Ľutujeme, detaily k piesni nie sú dostupné.';
+
+/**
+ * General info for one event: name, date, song list (expandable tags).
+ * Used by EventDetail page. Kept as separate component so EventDetail can add more sections later.
+ */
+export function EventInfo() {
+    const { bem } = useBem('view-calendar-event-info');
+    const { id } = useParams<{ id: string }>();
+    const { data: event, isLoading, isError } = useEventDetail(id);
+    const [expandedSongIds, setExpandedSongIds] = useState<Set<string>>(new Set());
+
+    if (!id) {
+        return <div className={bem()}>Event ID is required.</div>;
+    }
+
+    if (isLoading) return <Loader />;
+    if (isError || !event) {
+        return <div className={bem()}>Event not found.</div>;
+    }
+
+    const mappedSongs = event.songs.filter(hasSongTitle);
+    const hasMappedSongs = mappedSongs.length > 0;
+
+    return (
+        <div className={bem()}>
+            <h1 className={bem('title')}>Detail slávenia</h1>
+            <div className={bem('content')}>
+                <aside className={bem('meta')}>
+                    <h2 className={bem('meta-title')}>{event.name}</h2>
+                    <p className={bem('meta-date')}>{formatDate(event.date, 'datum')}</p>
+                </aside>
+                <div className={bem('songs')}>
+                    {!hasMappedSongs ? (
+                        <p className={bem('songs-empty')}>
+                            {EMPTY_SONGS_MESSAGE}
+                        </p>
+                    ) : (
+                        <ol className={bem('song-list')}>
+                            {mappedSongs.map((song) => {
+                                const isSongExpanded =
+                                    expandedSongIds.has(song.id);
+                                const sortedTags =
+                                    getSortedTags(song.tags);
+                                const hasTagsToShow =
+                                    sortedTags.length > 0;
+                                const showUnavailableRollout =
+                                    isSongExpanded && !hasTagsToShow;
+                                const toggleSongExpanded = () => {
+                                    setExpandedSongIds((prev) => {
+                                        const next = new Set(prev);
+                                        if (next.has(song.id)) next.delete(song.id);
+                                        else next.add(song.id);
+                                        return next;
+                                    });
+                                };
+                                return (
+                                    <li
+                                        key={song.id}
+                                        className={bem('song-item', {
+                                            expanded: isSongExpanded,
+                                        })}
+                                    >
+                                        <div className={bem('song-row')}>
+                                            <button
+                                                type="button"
+                                                className={bem(
+                                                    'song-title'
+                                                )}
+                                                onClick={toggleSongExpanded}
+                                            >
+                                                {song.title}
+                                            </button>
+                                            <span
+                                                className={bem(
+                                                    'song-author'
+                                                )}
+                                            >
+                                                {song.author ?? ''}
+                                            </span>
+                                            <span
+                                                className={bem(
+                                                    'song-meta'
+                                                )}
+                                            >
+                                                {song.hymnal ?? ''}
+                                            </span>
+                                            <button
+                                                type="button"
+                                                className={bem(
+                                                    'song-chevron'
+                                                )}
+                                                onClick={toggleSongExpanded}
+                                                aria-expanded={
+                                                    isSongExpanded
+                                                }
+                                                aria-label={
+                                                    isSongExpanded
+                                                        ? 'Zbaliť'
+                                                        : 'Rozbaliť'
+                                                }
+                                            >
+                                                <ChevronIcon
+                                                    direction={
+                                                        isSongExpanded
+                                                            ? 'up'
+                                                            : 'down'
+                                                    }
+                                                    className={bem(
+                                                        'song-chevron-icon'
+                                                    )}
+                                                    aria-hidden={true}
+                                                />
+                                            </button>
+                                        </div>
+                                        {isSongExpanded && hasTagsToShow && (
+                                            <div
+                                                className={bem(
+                                                    'song-tags-rollout'
+                                                )}
+                                            >
+                                                {sortedTags.map(
+                                                    (tag, i) => (
+                                                        <span
+                                                            key={tag}
+                                                            className={bem(
+                                                                'song-tag'
+                                                            )}
+                                                        >
+                                                            {TAG_LETTERS[i] ??
+                                                                `${i + 1}.`}.{' '}
+                                                            {tag}
+                                                        </span>
+                                                    )
+                                                )}
+                                            </div>
+                                        )}
+                                        {showUnavailableRollout && (
+                                            <div
+                                                className={bem(
+                                                    'song-unavailable-rollout'
+                                                )}
+                                                role="status"
+                                            >
+                                                <p
+                                                    className={bem(
+                                                        'song-unavailable-text'
+                                                    )}
+                                                >
+                                                    {SONG_UNAVAILABLE_MESSAGE}
+                                                </p>
+                                            </div>
+                                        )}
+                                    </li>
+                                );
+                            })}
+                        </ol>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/views/calendarView/EventInfo.tsx
+++ b/src/views/calendarView/EventInfo.tsx
@@ -3,6 +3,7 @@ import { useBem } from '@musica-sacra/hooks';
 import { useParams } from 'react-router';
 import { Loader } from '@musica-sacra/loader';
 import { useEventDetail } from './useEventDetail';
+import type { EventSong } from './useEventDetail';
 import { ChevronIcon } from './ChevronIcon';
 import {
     formatDate,
@@ -15,8 +16,29 @@ const EMPTY_SONGS_MESSAGE =
     'Pre toto slavenie nie sú aktuálne dostupné žiadne piesne.';
 const SONG_UNAVAILABLE_MESSAGE = 'Ľutujeme, detaily k piesni nie sú dostupné.';
 
+/** Display order for event parts (Introit, Zalm, Offertorium, Zaver). */
+const EVENT_PART_ORDER = ['Introit', 'Zalm', 'Offertorium', 'Zaver'] as const;
+
+/** Label for song part (stanza/block), e.g. "1. sloha", "piata sloha". */
+function getSongPartLabel(song: EventSong): string {
+    if (song.songPartName?.trim()) return song.songPartName;
+    if (song.songPart != null) return `${song.songPart}. sloha`;
+    return '';
+}
+
+function groupSongsByEventPart(songs: EventSong[]): Map<string, EventSong[]> {
+    const map = new Map<string, EventSong[]>();
+    for (const song of songs) {
+        const part = song.eventPart || 'Ostatné';
+        const list = map.get(part);
+        if (list) list.push(song);
+        else map.set(part, [song]);
+    }
+    return map;
+}
+
 /**
- * General info for one event: name, date, song list (expandable tags).
+ * General info for one event: name, description, date, then songs grouped by part (Introit, Offertorium, Zaver).
  * Used by EventDetail page. Kept as separate component so EventDetail can add more sections later.
  */
 export function EventInfo() {
@@ -38,131 +60,174 @@ export function EventInfo() {
 
     const mappedSongs = event.songs.filter(hasSongTitle);
     const hasMappedSongs = mappedSongs.length > 0;
+    const songsByPart = groupSongsByEventPart(mappedSongs);
 
     return (
         <div className={bem()}>
-            <h1 className={bem('title')}>Detail slávenia</h1>
-            <div className={bem('content')}>
-                <aside className={bem('meta')}>
-                    <h2 className={bem('meta-title')}>{event.name}</h2>
-                    <p className={bem('meta-date')}>
-                        {formatDate(event.date, 'datum')}
-                    </p>
-                </aside>
-                <div className={bem('songs')}>
-                    {!hasMappedSongs ? (
-                        <p className={bem('songs-empty')}>
-                            {EMPTY_SONGS_MESSAGE}
-                        </p>
-                    ) : (
-                        <ol className={bem('song-list')}>
-                            {mappedSongs.map((song) => {
-                                const isSongExpanded = expandedSongIds.has(
-                                    song.id
-                                );
-                                const sortedTags = getSortedTags(song.tags);
-                                const hasTagsToShow = sortedTags.length > 0;
-                                const showUnavailableRollout =
-                                    isSongExpanded && !hasTagsToShow;
-                                const toggleSongExpanded = () => {
-                                    setExpandedSongIds((prev) => {
-                                        const next = new Set(prev);
-                                        if (next.has(song.id))
-                                            next.delete(song.id);
-                                        else next.add(song.id);
-                                        return next;
-                                    });
-                                };
-                                return (
-                                    <li
-                                        key={song.id}
-                                        className={bem('song-item', {
-                                            expanded: isSongExpanded,
-                                        })}
+            <header className={bem('header')}>
+                <h1 className={bem('event-title')}>{event.name}</h1>
+                {event.description != null && event.description !== '' && (
+                    <p className={bem('description')}>{event.description}</p>
+                )}
+                <p className={bem('date')}>{formatDate(event.date, 'datum')}</p>
+                <div className={bem('placeholder')} aria-hidden>
+                    {/* Placeholder for future meta */}
+                </div>
+            </header>
+
+            {!hasMappedSongs ? (
+                <p className={bem('songs-empty')}>{EMPTY_SONGS_MESSAGE}</p>
+            ) : (
+                <div className={bem('parts')}>
+                    {EVENT_PART_ORDER.map((partName) => {
+                        const partSongs = songsByPart.get(partName);
+                        if (!partSongs?.length) return null;
+                        return (
+                            <section
+                                key={partName}
+                                className={bem('part-section')}
+                                aria-labelledby={`event-info-part-${partName}`}
+                            >
+                                <h2
+                                    id={`event-info-part-${partName}`}
+                                    className={bem('part-heading')}
+                                >
+                                    {partName}:
+                                </h2>
+                                <ul className={bem('part-song-list')}>
+                                    {partSongs.map((song) => (
+                                        <EventInfoSongItem
+                                            key={song.id}
+                                            song={song}
+                                            bem={bem}
+                                            expandedSongIds={expandedSongIds}
+                                            setExpandedSongIds={
+                                                setExpandedSongIds
+                                            }
+                                        />
+                                    ))}
+                                </ul>
+                            </section>
+                        );
+                    })}
+                    {/* Any part not in EVENT_PART_ORDER (e.g. custom parts) */}
+                    {Array.from(songsByPart.entries()).map(
+                        ([partName, partSongs]) => {
+                            if (
+                                EVENT_PART_ORDER.includes(
+                                    partName as (typeof EVENT_PART_ORDER)[number]
+                                )
+                            )
+                                return null;
+                            return (
+                                <section
+                                    key={partName}
+                                    className={bem('part-section')}
+                                    aria-labelledby={`event-info-part-${partName}`}
+                                >
+                                    <h2
+                                        id={`event-info-part-${partName}`}
+                                        className={bem('part-heading')}
                                     >
-                                        <div className={bem('song-row')}>
-                                            <button
-                                                type="button"
-                                                className={bem('song-title')}
-                                                onClick={toggleSongExpanded}
-                                            >
-                                                {song.title}
-                                            </button>
-                                            <span
-                                                className={bem('song-author')}
-                                            >
-                                                {song.author ?? ''}
-                                            </span>
-                                            <span className={bem('song-meta')}>
-                                                {song.hymnal ?? ''}
-                                            </span>
-                                            <button
-                                                type="button"
-                                                className={bem('song-chevron')}
-                                                onClick={toggleSongExpanded}
-                                                aria-expanded={isSongExpanded}
-                                                aria-label={
-                                                    isSongExpanded
-                                                        ? 'Zbaliť'
-                                                        : 'Rozbaliť'
+                                        {partName}:
+                                    </h2>
+                                    <ul className={bem('part-song-list')}>
+                                        {partSongs.map((song) => (
+                                            <EventInfoSongItem
+                                                key={song.id}
+                                                song={song}
+                                                bem={bem}
+                                                expandedSongIds={
+                                                    expandedSongIds
                                                 }
-                                            >
-                                                <ChevronIcon
-                                                    direction={
-                                                        isSongExpanded
-                                                            ? 'up'
-                                                            : 'down'
-                                                    }
-                                                    className={bem(
-                                                        'song-chevron-icon'
-                                                    )}
-                                                    aria-hidden={true}
-                                                />
-                                            </button>
-                                        </div>
-                                        {isSongExpanded && hasTagsToShow && (
-                                            <div
-                                                className={bem(
-                                                    'song-tags-rollout'
-                                                )}
-                                            >
-                                                {sortedTags.map((tag, i) => (
-                                                    <span
-                                                        key={tag}
-                                                        className={bem(
-                                                            'song-tag'
-                                                        )}
-                                                    >
-                                                        {TAG_LETTERS[i] ??
-                                                            `${i + 1}.`}
-                                                        . {tag}
-                                                    </span>
-                                                ))}
-                                            </div>
-                                        )}
-                                        {showUnavailableRollout && (
-                                            <div
-                                                className={bem(
-                                                    'song-unavailable-rollout'
-                                                )}
-                                                role="status"
-                                            >
-                                                <p
-                                                    className={bem(
-                                                        'song-unavailable-text'
-                                                    )}
-                                                >
-                                                    {SONG_UNAVAILABLE_MESSAGE}
-                                                </p>
-                                            </div>
-                                        )}
-                                    </li>
-                                );
-                            })}
-                        </ol>
+                                                setExpandedSongIds={
+                                                    setExpandedSongIds
+                                                }
+                                            />
+                                        ))}
+                                    </ul>
+                                </section>
+                            );
+                        }
                     )}
                 </div>
-            </div>
+            )}
         </div>
+    );
+}
+
+type EventInfoSongItemProps = {
+    song: EventSong;
+    bem: ReturnType<typeof useBem>['bem'];
+    expandedSongIds: Set<string>;
+    setExpandedSongIds: React.Dispatch<React.SetStateAction<Set<string>>>;
+};
+
+function EventInfoSongItem({
+    song,
+    bem,
+    expandedSongIds,
+    setExpandedSongIds,
+}: EventInfoSongItemProps) {
+    const isSongExpanded = expandedSongIds.has(song.id);
+    const sortedTags = getSortedTags(song.tags);
+    const hasTagsToShow = sortedTags.length > 0;
+    const showUnavailableRollout = isSongExpanded && !hasTagsToShow;
+    const partLabel = getSongPartLabel(song);
+    const titleLine =
+        partLabel !== '' ? `${song.title} - ${partLabel}` : song.title;
+
+    const toggleSongExpanded = () => {
+        setExpandedSongIds((prev) => {
+            const next = new Set(prev);
+            if (next.has(song.id)) next.delete(song.id);
+            else next.add(song.id);
+            return next;
+        });
+    };
+
+    return (
+        <li className={bem('song-item', { expanded: isSongExpanded })}>
+            <div className={bem('song-row')}>
+                <button
+                    type="button"
+                    className={bem('song-title')}
+                    onClick={toggleSongExpanded}
+                >
+                    {titleLine}
+                </button>
+                <span className={bem('song-author')}>{song.author ?? ''}</span>
+                <span className={bem('song-meta')}>{song.hymnal ?? ''}</span>
+                <button
+                    type="button"
+                    className={bem('song-chevron')}
+                    onClick={toggleSongExpanded}
+                    aria-expanded={isSongExpanded}
+                    aria-label={isSongExpanded ? 'Zbaliť' : 'Rozbaliť'}
+                >
+                    <ChevronIcon
+                        direction={isSongExpanded ? 'up' : 'down'}
+                        className={bem('song-chevron-icon')}
+                        aria-hidden={true}
+                    />
+                </button>
+            </div>
+            {isSongExpanded && hasTagsToShow && (
+                <div className={bem('song-tags-rollout')}>
+                    {sortedTags.map((tag, i) => (
+                        <span key={tag} className={bem('song-tag')}>
+                            {TAG_LETTERS[i] ?? `${i + 1}.`}. {tag}
+                        </span>
+                    ))}
+                </div>
+            )}
+            {showUnavailableRollout && (
+                <div className={bem('song-unavailable-rollout')} role="status">
+                    <p className={bem('song-unavailable-text')}>
+                        {SONG_UNAVAILABLE_MESSAGE}
+                    </p>
+                </div>
+            )}
+        </li>
     );
 }

--- a/src/views/calendarView/EventsList.tsx
+++ b/src/views/calendarView/EventsList.tsx
@@ -35,8 +35,7 @@ type EventDetailContentProps = {
 
 const EMPTY_SONGS_MESSAGE =
     'Pre toto slavenie nie sú aktuálne dostupné žiadne piesne.';
-const SONG_UNAVAILABLE_MESSAGE =
-    'Ľutujeme, detaily k piesni nie sú dostupné.';
+const SONG_UNAVAILABLE_MESSAGE = 'Ľutujeme, detaily k piesni nie sú dostupné.';
 
 function EventDetailContent({
     eventId,
@@ -48,9 +47,7 @@ function EventDetailContent({
     const mappedSongs = eventDetail.songs.filter(hasSongTitle);
     if (mappedSongs.length === 0) {
         return (
-            <p className={bem('item-detail-empty')}>
-                {EMPTY_SONGS_MESSAGE}
-            </p>
+            <p className={bem('item-detail-empty')}>{EMPTY_SONGS_MESSAGE}</p>
         );
     }
     return (
@@ -94,9 +91,7 @@ function EventSongRow({
     const onToggle = () => toggleSongExpanded(eventId, song.id);
 
     return (
-        <li
-            className={bem('item-detail-song', { expanded: isSongExpanded })}
-        >
+        <li className={bem('item-detail-song', { expanded: isSongExpanded })}>
             <div className={bem('item-detail-song-row')}>
                 <button
                     type="button"
@@ -153,7 +148,9 @@ export function EventsList() {
     const [searchParams] = useSearchParams();
     const categoryId = searchParams.get('category');
     const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
-    const [expandedSongKeys, setExpandedSongKeys] = useState<Set<string>>(new Set());
+    const [expandedSongKeys, setExpandedSongKeys] = useState<Set<string>>(
+        new Set()
+    );
 
     const { data, isLoading } = useQuery({
         queryKey: ['eventCategoryDetail'],
@@ -201,16 +198,26 @@ export function EventsList() {
                     <ol className={bem('list')}>
                         {items.map((event, index) => {
                             const isExpanded = expandedIds.has(event.id);
-                            const eventDetail = detailsMap[String(event.id)] ?? null;
+                            const eventDetail =
+                                detailsMap[String(event.id)] ?? null;
                             return (
-                                <li key={event.id} className={bem('item', { expanded: isExpanded })}>
+                                <li
+                                    key={event.id}
+                                    className={bem('item', {
+                                        expanded: isExpanded,
+                                    })}
+                                >
                                     <div className={bem('item-row')}>
-                                        <span className={bem('item-number')}>{index + 1}.</span>
+                                        <span className={bem('item-number')}>
+                                            {index + 1}.
+                                        </span>
                                         <div className={bem('item-body')}>
                                             <button
                                                 type="button"
                                                 className={bem('item-title')}
-                                                onClick={() => handleRowClick(event.id)}
+                                                onClick={() =>
+                                                    handleRowClick(event.id)
+                                                }
                                                 aria-expanded={isExpanded}
                                                 aria-controls={`event-detail-${event.id}`}
                                             >
@@ -218,7 +225,11 @@ export function EventsList() {
                                             </button>
                                             {event.description != null &&
                                                 event.description !== '' && (
-                                                    <span className={bem('item-description')}>
+                                                    <span
+                                                        className={bem(
+                                                            'item-description'
+                                                        )}
+                                                    >
                                                         {event.description}
                                                     </span>
                                                 )}
@@ -229,13 +240,23 @@ export function EventsList() {
                                         <button
                                             type="button"
                                             className={bem('item-chevron')}
-                                            onClick={() => handleRowClick(event.id)}
-                                            aria-label={isExpanded ? 'Zbaliť' : 'Rozbaliť'}
+                                            onClick={() =>
+                                                handleRowClick(event.id)
+                                            }
+                                            aria-label={
+                                                isExpanded
+                                                    ? 'Zbaliť'
+                                                    : 'Rozbaliť'
+                                            }
                                             aria-expanded={isExpanded}
                                         >
                                             <ChevronIcon
-                                                direction={isExpanded ? 'up' : 'down'}
-                                                className={bem('item-chevron-icon')}
+                                                direction={
+                                                    isExpanded ? 'up' : 'down'
+                                                }
+                                                className={bem(
+                                                    'item-chevron-icon'
+                                                )}
                                                 aria-hidden={true}
                                             />
                                         </button>
@@ -247,18 +268,32 @@ export function EventsList() {
                                             role="region"
                                             aria-label={`Detail: ${event.name}`}
                                         >
-                                            {isExpanded && detailLoading && !eventDetail ? (
-                                                <Loader key={`loader-${event.id}`} />
+                                            {isExpanded &&
+                                            detailLoading &&
+                                            !eventDetail ? (
+                                                <Loader
+                                                    key={`loader-${event.id}`}
+                                                />
                                             ) : eventDetail ? (
                                                 <EventDetailContent
                                                     eventId={event.id}
                                                     eventDetail={eventDetail}
-                                                    expandedSongKeys={expandedSongKeys}
-                                                    toggleSongExpanded={toggleSongExpanded}
+                                                    expandedSongKeys={
+                                                        expandedSongKeys
+                                                    }
+                                                    toggleSongExpanded={
+                                                        toggleSongExpanded
+                                                    }
                                                     bem={bem}
                                                 />
                                             ) : (
-                                                <p className={bem('item-detail-error')}>Detail sa nenašiel.</p>
+                                                <p
+                                                    className={bem(
+                                                        'item-detail-error'
+                                                    )}
+                                                >
+                                                    Detail sa nenašiel.
+                                                </p>
                                             )}
                                         </div>
                                     )}

--- a/src/views/calendarView/EventsList.tsx
+++ b/src/views/calendarView/EventsList.tsx
@@ -1,0 +1,273 @@
+import { useState } from 'react';
+import { useBem } from '@musica-sacra/hooks';
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import { Loader } from '@musica-sacra/loader';
+import { useSearchParams } from 'react-router';
+import { useEventDetails } from './useEventDetail';
+import type { EventDetailData, EventSong } from './useEventDetail';
+import { ChevronIcon } from './ChevronIcon';
+import {
+    formatDate,
+    getSortedTags,
+    TAG_LETTERS,
+    hasSongTitle,
+} from './calendarViewUtils';
+
+type EventItem = {
+    id: number;
+    name: string;
+    description?: string;
+    date: { day: number; month: number } | null;
+};
+
+type EventCategoryDetailResponse = Record<string, { items: EventItem[] }>;
+
+type BemFn = ReturnType<typeof useBem>['bem'];
+
+type EventDetailContentProps = {
+    eventId: number;
+    eventDetail: EventDetailData;
+    expandedSongKeys: Set<string>;
+    toggleSongExpanded: (eventId: number, songId: string) => void;
+    bem: BemFn;
+};
+
+const EMPTY_SONGS_MESSAGE =
+    'Pre toto slavenie nie sú aktuálne dostupné žiadne piesne.';
+const SONG_UNAVAILABLE_MESSAGE =
+    'Ľutujeme, detaily k piesni nie sú dostupné.';
+
+function EventDetailContent({
+    eventId,
+    eventDetail,
+    expandedSongKeys,
+    toggleSongExpanded,
+    bem,
+}: EventDetailContentProps) {
+    const mappedSongs = eventDetail.songs.filter(hasSongTitle);
+    if (mappedSongs.length === 0) {
+        return (
+            <p className={bem('item-detail-empty')}>
+                {EMPTY_SONGS_MESSAGE}
+            </p>
+        );
+    }
+    return (
+        <div className={bem('item-detail-songs')}>
+            <ol className={bem('item-detail-song-list')}>
+                {mappedSongs.map((song) => (
+                    <EventSongRow
+                        key={song.id}
+                        song={song}
+                        eventId={eventId}
+                        expandedSongKeys={expandedSongKeys}
+                        toggleSongExpanded={toggleSongExpanded}
+                        bem={bem}
+                    />
+                ))}
+            </ol>
+        </div>
+    );
+}
+
+type EventSongRowProps = {
+    song: EventSong;
+    eventId: number;
+    expandedSongKeys: Set<string>;
+    toggleSongExpanded: (eventId: number, songId: string) => void;
+    bem: BemFn;
+};
+
+function EventSongRow({
+    song,
+    eventId,
+    expandedSongKeys,
+    toggleSongExpanded,
+    bem,
+}: EventSongRowProps) {
+    const songKey = `${eventId}-${song.id}`;
+    const isSongExpanded = expandedSongKeys.has(songKey);
+    const sortedTags = getSortedTags(song.tags);
+    const hasTagsToShow = sortedTags.length > 0;
+    const showUnavailableRollout = isSongExpanded && !hasTagsToShow;
+    const onToggle = () => toggleSongExpanded(eventId, song.id);
+
+    return (
+        <li
+            className={bem('item-detail-song', { expanded: isSongExpanded })}
+        >
+            <div className={bem('item-detail-song-row')}>
+                <button
+                    type="button"
+                    className={bem('item-detail-song-title')}
+                    onClick={onToggle}
+                >
+                    {song.title}
+                </button>
+                <span className={bem('item-detail-song-author')}>
+                    {song.author ?? ''}
+                </span>
+                <span className={bem('item-detail-song-meta')}>
+                    {song.hymnal ?? ''}
+                </span>
+                <button
+                    type="button"
+                    className={bem('item-detail-song-chevron')}
+                    onClick={onToggle}
+                    aria-expanded={isSongExpanded}
+                    aria-label={isSongExpanded ? 'Zbaliť' : 'Rozbaliť'}
+                >
+                    <ChevronIcon
+                        direction={isSongExpanded ? 'up' : 'down'}
+                        className={bem('item-detail-song-chevron-icon')}
+                        aria-hidden={true}
+                    />
+                </button>
+            </div>
+            {isSongExpanded && hasTagsToShow && (
+                <div className={bem('item-detail-song-tags-rollout')}>
+                    {sortedTags.map((tag, i) => (
+                        <span key={tag} className={bem('item-detail-song-tag')}>
+                            {TAG_LETTERS[i] ?? `${i + 1}.`}. {tag}
+                        </span>
+                    ))}
+                </div>
+            )}
+            {showUnavailableRollout && (
+                <div
+                    className={bem('item-detail-song-unavailable-rollout')}
+                    role="status"
+                >
+                    <p className={bem('item-detail-song-unavailable-text')}>
+                        {SONG_UNAVAILABLE_MESSAGE}
+                    </p>
+                </div>
+            )}
+        </li>
+    );
+}
+
+export function EventsList() {
+    const { bem } = useBem('view-calendar-events');
+    const [searchParams] = useSearchParams();
+    const categoryId = searchParams.get('category');
+    const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
+    const [expandedSongKeys, setExpandedSongKeys] = useState<Set<string>>(new Set());
+
+    const { data, isLoading } = useQuery({
+        queryKey: ['eventCategoryDetail'],
+        queryFn: async (): Promise<EventCategoryDetailResponse> => {
+            const { data: res } = await axios.get<EventCategoryDetailResponse>(
+                '/mocks/eventCategoryDetail.json'
+            );
+            return res ?? {};
+        },
+    });
+
+    const expandedIdList = Array.from(expandedIds);
+    const { data: detailsMap, isLoading: detailLoading } = useEventDetails(
+        expandedIdList.map(String)
+    );
+
+    const items = categoryId != null ? (data?.[categoryId]?.items ?? []) : [];
+
+    const handleRowClick = (id: number) => {
+        setExpandedIds((current) => {
+            const next = new Set(current);
+            if (next.has(id)) next.delete(id);
+            else next.add(id);
+            return next;
+        });
+    };
+
+    const toggleSongExpanded = (eventId: number, songId: string) => {
+        const key = `${eventId}-${songId}`;
+        setExpandedSongKeys((prev) => {
+            const next = new Set(prev);
+            if (next.has(key)) next.delete(key);
+            else next.add(key);
+            return next;
+        });
+    };
+
+    return (
+        <div className={bem()}>
+            <h1 className={bem('title')}>Kalendar - slávenia</h1>
+            {categoryId == null ? (
+                <p className={bem('hint')}>Vyberte kategóriu v menu vľavo.</p>
+            ) : (
+                <Loader loading={isLoading}>
+                    <ol className={bem('list')}>
+                        {items.map((event, index) => {
+                            const isExpanded = expandedIds.has(event.id);
+                            const eventDetail = detailsMap[String(event.id)] ?? null;
+                            return (
+                                <li key={event.id} className={bem('item', { expanded: isExpanded })}>
+                                    <div className={bem('item-row')}>
+                                        <span className={bem('item-number')}>{index + 1}.</span>
+                                        <div className={bem('item-body')}>
+                                            <button
+                                                type="button"
+                                                className={bem('item-title')}
+                                                onClick={() => handleRowClick(event.id)}
+                                                aria-expanded={isExpanded}
+                                                aria-controls={`event-detail-${event.id}`}
+                                            >
+                                                {event.name}
+                                            </button>
+                                            {event.description != null &&
+                                                event.description !== '' && (
+                                                    <span className={bem('item-description')}>
+                                                        {event.description}
+                                                    </span>
+                                                )}
+                                        </div>
+                                        <span className={bem('item-date')}>
+                                            {formatDate(event.date)}
+                                        </span>
+                                        <button
+                                            type="button"
+                                            className={bem('item-chevron')}
+                                            onClick={() => handleRowClick(event.id)}
+                                            aria-label={isExpanded ? 'Zbaliť' : 'Rozbaliť'}
+                                            aria-expanded={isExpanded}
+                                        >
+                                            <ChevronIcon
+                                                direction={isExpanded ? 'up' : 'down'}
+                                                className={bem('item-chevron-icon')}
+                                                aria-hidden={true}
+                                            />
+                                        </button>
+                                    </div>
+                                    {isExpanded && (
+                                        <div
+                                            id={`event-detail-${event.id}`}
+                                            className={bem('item-detail')}
+                                            role="region"
+                                            aria-label={`Detail: ${event.name}`}
+                                        >
+                                            {isExpanded && detailLoading && !eventDetail ? (
+                                                <Loader key={`loader-${event.id}`} />
+                                            ) : eventDetail ? (
+                                                <EventDetailContent
+                                                    eventId={event.id}
+                                                    eventDetail={eventDetail}
+                                                    expandedSongKeys={expandedSongKeys}
+                                                    toggleSongExpanded={toggleSongExpanded}
+                                                    bem={bem}
+                                                />
+                                            ) : (
+                                                <p className={bem('item-detail-error')}>Detail sa nenašiel.</p>
+                                            )}
+                                        </div>
+                                    )}
+                                </li>
+                            );
+                        })}
+                    </ol>
+                </Loader>
+            )}
+        </div>
+    );
+}

--- a/src/views/calendarView/calendarView.scss
+++ b/src/views/calendarView/calendarView.scss
@@ -259,53 +259,68 @@
     // Child: EventInfo (general info + songs)
 }
 
-// Event info block (meta left, songs right). Used inside EventDetail.
+// Event info block: header (title, description, date, placeholder) + parts (Introit, Offertorium, Zaver). Used inside EventDetail.
 .view-calendar-event-info {
-    &__title {
+    text-align: left;
+
+    &__header {
+        margin-bottom: 1.5rem;
+    }
+
+    &__event-title {
         font-size: 1.5rem;
-        margin: 0 0 1rem 0;
+        font-weight: 600;
         color: $primary;
+        margin: 0 0 0.5rem 0;
+        text-align: left;
     }
 
-    &__content {
-        display: grid;
-        grid-template-columns: 1fr 2fr;
-        gap: 2rem;
-
-        @media (max-width: 768px) {
-            grid-template-columns: 1fr;
-        }
+    &__description {
+        color: $secondary;
+        margin: 0 0 0.5rem 0;
+        line-height: 1.4;
+        text-align: left;
     }
 
-    &__meta {
-        &-title {
-            font-size: 1.25rem;
-            font-weight: 600;
-            color: $primary;
-            margin: 0 0 0.5rem 0;
-        }
-
-        &-date {
-            color: $tertiary;
-            margin: 0;
-        }
+    &__date {
+        color: $tertiary;
+        margin: 0 0 0.5rem 0;
+        text-align: left;
     }
 
-    &__songs {
+    &__placeholder {
+        margin: 0.5rem 0 0 0;
+        min-height: 1px;
+    }
+
+    &__parts {
         display: flex;
         flex-direction: column;
+        gap: 1.5rem;
+    }
+
+    &__part-section {
+        margin: 0;
+    }
+
+    &__part-heading {
+        font-size: 1.125rem;
+        font-weight: 600;
+        color: $primary;
+        margin: 0 0 0.5rem 0;
+        text-align: left;
+    }
+
+    &__part-song-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
     }
 
     &__songs-empty {
         color: $tertiary;
         margin: 0;
         padding: 0.5rem 0;
-    }
-
-    &__song-list {
-        list-style: none;
-        padding: 0;
-        margin: 0;
     }
 
     // Song item: row (title | author | hymnal | chevron) + tags rollout below when expanded

--- a/src/views/calendarView/calendarView.scss
+++ b/src/views/calendarView/calendarView.scss
@@ -1,0 +1,398 @@
+@use '../../styles/variables' as *;
+
+.view-calendar {
+    &__sidebar {
+        min-width: 100%;
+        width: 100%;
+    }
+}
+
+// Calendar sidebar: Kalendar title, Slavenia with separator, linear list of category links
+.view-calendar-sidebar {
+    padding: 1rem 0;
+
+    &__title {
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: $primary;
+        margin: 0 0 4rem 0;
+        text-align: left;
+    }
+
+    &__subtitle {
+        font-size: 1rem;
+        color: $secondary;
+        margin: 0 0 0.75rem 0;
+        padding-bottom: 0.75rem;
+        text-align: left;
+        border-bottom: $border-light;
+    }
+
+    &__nav {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        padding-top: 0.75rem;
+    }
+
+    &__link {
+        color: $secondary;
+        text-decoration: none;
+
+        &:hover {
+            color: $accent;
+        }
+
+        &--active {
+            color: $accent;
+        }
+    }
+}
+
+// Events list: title, numbered list, item with name/description/date and arrow
+.view-calendar-events {
+    &__title {
+        font-size: 1.5rem;
+        margin: 0 0 1rem 0;
+        color: $primary;
+    }
+
+    &__hint {
+        color: $tertiary;
+    }
+
+    &__list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
+
+    &__item {
+        border-bottom: $border;
+    }
+
+    &__item-row {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.75rem;
+        padding: 0.75rem 0;
+    }
+
+    &__item-number {
+        flex-shrink: 0;
+        color: $tertiary;
+    }
+
+    &__item-body {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        flex: 1;
+    }
+
+    &__item-title {
+        font-weight: 500;
+        color: $primary;
+        background: none;
+        border: none;
+        padding: 0;
+        cursor: pointer;
+        text-align: left;
+        font-size: inherit;
+        font-family: inherit;
+
+        &:hover {
+            color: $accent;
+        }
+    }
+
+    &__item-description {
+        font-size: 0.875rem;
+        color: $tertiary;
+    }
+
+    &__item-date {
+        flex-shrink: 0;
+        color: $tertiary;
+    }
+
+    &__item-chevron {
+        flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: none;
+        border: none;
+        padding: 0.25rem;
+        cursor: pointer;
+        color: $accent;
+
+        &:hover {
+            opacity: 0.8;
+        }
+    }
+
+    &__item-chevron-icon {
+        display: block;
+    }
+
+    &__item-detail {
+        padding: 1rem 0 1rem 2rem;
+        margin-bottom: 0.5rem;
+        background-color: $background-secondary;
+        border-radius: $border-radius-small;
+    }
+
+    &__item-detail-songs {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    &__item-detail-song-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
+
+    &__item-detail-empty {
+        color: $tertiary;
+        margin: 0;
+        padding: 0.5rem 0;
+    }
+
+    // Song item: row (title | author | hymnal | chevron) + tags rollout below when expanded
+    &__item-detail-song {
+        padding: 0.35rem 0;
+        font-size: 0.875rem;
+    }
+
+    &__item-detail-song-row {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+    }
+
+    &__item-detail-song-title {
+        flex: 6;
+        min-width: 0;
+        color: $primary;
+        text-decoration: none;
+        background: none;
+        border: none;
+        padding: 0;
+        cursor: pointer;
+        text-align: left;
+        font-size: inherit;
+        font-family: inherit;
+
+        &:hover {
+            color: $accent;
+        }
+    }
+
+    &__item-detail-song-author {
+        flex: 3;
+        color: $tertiary;
+    }
+
+    &__item-detail-song-meta {
+        flex: 2;
+        padding-right: 0.75rem;
+        color: $tertiary;
+    }
+
+    &__item-detail-song-chevron {
+        flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: none;
+        border: none;
+        padding: 0.25rem;
+        cursor: pointer;
+        color: $accent;
+        margin-left: auto;
+
+        &:hover {
+            opacity: 0.8;
+        }
+    }
+
+    &__item-detail-song-chevron-icon {
+        display: block;
+    }
+
+    &__item-detail-song-tags-rollout {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.15rem;
+        padding: 0.5rem 0 0 0;
+        margin-left: 0;
+        color: $tertiary;
+        font-size: 0.8125rem;
+    }
+
+    &__item-detail-song-tag {
+        display: block;
+    }
+
+    &__item-detail-song-unavailable-rollout {
+        padding: 0.5rem 0 0 0;
+        color: $tertiary;
+        font-size: 0.875rem;
+    }
+
+    &__item-detail-song-unavailable-text {
+        margin: 0;
+    }
+
+    &__item-detail-error {
+        color: $tertiary;
+        margin: 0;
+    }
+}
+
+// Event detail page wrapper (EventDetail). Add page-level styles here.
+.view-calendar-event-detail {
+    // Child: EventInfo (general info + songs)
+}
+
+// Event info block (meta left, songs right). Used inside EventDetail.
+.view-calendar-event-info {
+    &__title {
+        font-size: 1.5rem;
+        margin: 0 0 1rem 0;
+        color: $primary;
+    }
+
+    &__content {
+        display: grid;
+        grid-template-columns: 1fr 2fr;
+        gap: 2rem;
+
+        @media (max-width: 768px) {
+            grid-template-columns: 1fr;
+        }
+    }
+
+    &__meta {
+        &-title {
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: $primary;
+            margin: 0 0 0.5rem 0;
+        }
+
+        &-date {
+            color: $tertiary;
+            margin: 0;
+        }
+    }
+
+    &__songs {
+        display: flex;
+        flex-direction: column;
+    }
+
+    &__songs-empty {
+        color: $tertiary;
+        margin: 0;
+        padding: 0.5rem 0;
+    }
+
+    &__song-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
+
+    // Song item: row (title | author | hymnal | chevron) + tags rollout below when expanded
+    &__song-item {
+        padding: 0.5rem 0;
+        border-bottom: $border-light;
+        font-size: 0.875rem;
+    }
+
+    &__song-row {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+    }
+
+    &__song-title {
+        flex: 6;
+        min-width: 0;
+        color: $primary;
+        text-decoration: none;
+        background: none;
+        border: none;
+        padding: 0;
+        cursor: pointer;
+        text-align: left;
+        font-size: inherit;
+        font-family: inherit;
+
+        &:hover {
+            color: $accent;
+        }
+    }
+
+    &__song-author {
+        flex: 3;
+        color: $tertiary;
+    }
+
+    &__song-meta {
+        flex: 2;
+        padding-right: 0.75rem;
+        color: $tertiary;
+    }
+
+    &__song-chevron {
+        flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: none;
+        border: none;
+        padding: 0.25rem;
+        cursor: pointer;
+        color: $accent;
+        margin-left: auto;
+
+        &:hover {
+            opacity: 0.8;
+        }
+    }
+
+    &__song-chevron-icon {
+        display: block;
+    }
+
+    &__song-tags-rollout {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.15rem;
+        padding: 0.5rem 0 0 0;
+        margin-left: 0;
+        color: $tertiary;
+        font-size: 0.8125rem;
+    }
+
+    &__song-tag {
+        display: block;
+    }
+
+    &__song-unavailable-rollout {
+        padding: 0.5rem 0 0 0;
+        color: $tertiary;
+        font-size: 0.875rem;
+    }
+
+    &__song-unavailable-text {
+        margin: 0;
+    }
+}

--- a/src/views/calendarView/calendarViewUtils.ts
+++ b/src/views/calendarView/calendarViewUtils.ts
@@ -1,0 +1,21 @@
+/** Formats event date (dd.mm.). emptyLabel when date is null (e.g. 'Datum' in list, 'datum' in meta). */
+export function formatDate(
+    date: { day: number; month: number } | null,
+    emptyLabel: string = 'Datum'
+): string {
+    if (!date) return emptyLabel;
+    return `${String(date.day).padStart(2, '0')}.${String(date.month).padStart(2, '0')}.`;
+}
+
+/** Tags sorted alphabetically (lowercase). Used with TAG_LETTERS for a. b. c. labels. */
+export function getSortedTags(tags: string[] | undefined): string[] {
+    if (!tags?.length) return [];
+    return [...tags].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+}
+
+export const TAG_LETTERS = 'abcdefghijklmnopqrstuvwxyz'.split('');
+
+/** True when song has a non-empty title. Use to filter displayable songs. */
+export function hasSongTitle(song: { title?: string | null }): boolean {
+    return song.title != null && song.title !== '';
+}

--- a/src/views/calendarView/calendarViewUtils.ts
+++ b/src/views/calendarView/calendarViewUtils.ts
@@ -10,7 +10,9 @@ export function formatDate(
 /** Tags sorted alphabetically (lowercase). Used with TAG_LETTERS for a. b. c. labels. */
 export function getSortedTags(tags: string[] | undefined): string[] {
     if (!tags?.length) return [];
-    return [...tags].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+    return [...tags].sort((a, b) =>
+        a.toLowerCase().localeCompare(b.toLowerCase())
+    );
 }
 
 export const TAG_LETTERS = 'abcdefghijklmnopqrstuvwxyz'.split('');

--- a/src/views/calendarView/useEventDetail.ts
+++ b/src/views/calendarView/useEventDetail.ts
@@ -1,0 +1,119 @@
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
+import axios from 'axios';
+
+/** Query keys for event detail. Use for invalidation (e.g. queryClient.invalidateQueries({ queryKey: EVENT_QUERY_KEYS.detail(id) })). */
+export const EVENT_QUERY_KEYS = {
+    detail: (id: string | undefined) => ['eventDetail', id] as const,
+    details: (ids: string[]) => ['eventDetails', ids.filter(Boolean).sort().join(',')] as const,
+};
+
+export type EventSong = {
+    id: string;
+    title: string;
+    /** Enriched from songs.json. */
+    author?: string;
+    /** Songbook code (e.g. JKS). Enriched from songs.json. */
+    hymnal?: string;
+    /** E.g. Introit, Offertorium. Enriched from songs.json, shown sorted. */
+    tags?: string[];
+    songPart: number | null;
+    songPartName: string | null;
+    prescribed: boolean;
+    eventPart: string;
+};
+
+export type EventDetailData = {
+    id: number;
+    name: string;
+    description?: string;
+    date: { day: number; month: number } | null;
+    songs: EventSong[];
+};
+
+/** Raw shape from event.json: id, eventPart, optional prescribed/songPart/songPartName. */
+type EventSongStub = {
+    id: string;
+    songPart: number | null;
+    songPartName: string | null;
+    prescribed: boolean;
+    eventPart: string;
+};
+
+type EventDetailRaw = Omit<EventDetailData, 'songs'> & {
+    songs: EventSongStub[];
+};
+
+type EventByIdResponse = Record<string, EventDetailRaw>;
+
+type SongsListResponse = {
+    items: Array<{ id: string; title?: string; author?: string; hymnal?: string; tags?: string[] }>;
+};
+
+function mergeEventWithSongs(
+    event: EventDetailRaw,
+    songsMap: Record<string, SongsListResponse['items'][number]>
+): EventDetailData {
+    const mergedSongs: EventSong[] = event.songs.map((es) => {
+        const song = songsMap[es.id];
+        return {
+            ...es,
+            title: song?.title ?? '',
+            author: song?.author ?? '',
+            hymnal: song?.hymnal ?? '',
+            tags: song?.tags ?? [],
+        };
+    });
+    return { ...event, songs: mergedSongs };
+}
+
+async function fetchEventDetails(
+    ids: string[]
+): Promise<Record<string, EventDetailData | null>> {
+    const [eventRes, songsRes] = await Promise.all([
+        axios.get<EventByIdResponse>('/mocks/event.json'),
+        axios.get<SongsListResponse>('/mocks/songs.json'),
+    ]);
+    const events = eventRes.data ?? {};
+    const songsList = songsRes.data?.items ?? [];
+    const songsMap = Object.fromEntries(songsList.map((s) => [s.id, s]));
+
+    const result: Record<string, EventDetailData | null> = {};
+    for (const id of ids) {
+        const event = events[id] ?? null;
+        result[id] = event ? mergeEventWithSongs(event, songsMap) : null;
+    }
+    return result;
+}
+
+export function useEventDetail(id: string | undefined) {
+    const query = useQuery({
+        queryKey: EVENT_QUERY_KEYS.detail(id),
+        queryFn: async (): Promise<EventDetailData | null> => {
+            if (id == null) return null;
+            const map = await fetchEventDetails([id]);
+            return map[id] ?? null;
+        },
+        enabled: id != null,
+    });
+
+    return {
+        ...query,
+        data: query.data ?? null,
+    };
+}
+
+/** Details for multiple event ids. Uses keepPreviousData so expanding another row does not clear existing data. */
+export function useEventDetails(ids: string[]) {
+    const sortedIds = [...ids].filter(Boolean).sort();
+    const query = useQuery({
+        queryKey: EVENT_QUERY_KEYS.details(ids),
+        placeholderData: keepPreviousData,
+        queryFn: () => fetchEventDetails(sortedIds),
+        enabled: sortedIds.length > 0,
+    });
+
+    return {
+        ...query,
+        data: query.data ?? {},
+    };
+}

--- a/src/views/calendarView/useEventDetail.ts
+++ b/src/views/calendarView/useEventDetail.ts
@@ -4,7 +4,8 @@ import axios from 'axios';
 /** Query keys for event detail. Use for invalidation (e.g. queryClient.invalidateQueries({ queryKey: EVENT_QUERY_KEYS.detail(id) })). */
 export const EVENT_QUERY_KEYS = {
     detail: (id: string | undefined) => ['eventDetail', id] as const,
-    details: (ids: string[]) => ['eventDetails', ids.filter(Boolean).sort().join(',')] as const,
+    details: (ids: string[]) =>
+        ['eventDetails', ids.filter(Boolean).sort().join(',')] as const,
 };
 
 export type EventSong = {
@@ -46,7 +47,13 @@ type EventDetailRaw = Omit<EventDetailData, 'songs'> & {
 type EventByIdResponse = Record<string, EventDetailRaw>;
 
 type SongsListResponse = {
-    items: Array<{ id: string; title?: string; author?: string; hymnal?: string; tags?: string[] }>;
+    items: Array<{
+        id: string;
+        title?: string;
+        author?: string;
+        hymnal?: string;
+        tags?: string[];
+    }>;
 };
 
 function mergeEventWithSongs(

--- a/src/views/homepageView/HomepageSidebar.tsx
+++ b/src/views/homepageView/HomepageSidebar.tsx
@@ -1,16 +1,9 @@
 import { useBem } from '@musica-sacra/hooks';
 import { Hr } from '../../components/hr/Hr';
-import { Tag } from '../../components/tag/Tag';
 import { SortFilters } from '../../components/sortFilters/SortFilters';
-import { TagCategory } from '../../models/tag';
-import { useGetList } from '@musica-sacra/api';
-import { Loader } from '@musica-sacra/loader';
-import { mockedTagCategories } from './mockedData';
 
 export function HomepageSidebar() {
     const { bem } = useBem('homepage-sidebar');
-
-    const { query } = useGetList('/mocks/tagCategories.json', 'tagCategories');
 
     return (
         <div className={bem()}>


### PR DESCRIPTION
- Calendar view with sidebar (categories) and events list
- Expandable event rows with song list and tags
- Event detail page (/calendar/:id) with EventInfo (name, date, songs)
- Mocks: eventCategories, eventCategoryDetail, event, songs
